### PR TITLE
[Fix]: fees references

### DIFF
--- a/docs/migration-0.3-0.4.md
+++ b/docs/migration-0.3-0.4.md
@@ -13,7 +13,7 @@ sidebar_label: 0.3 to 0.4
 - The fee amount must be correct as specified in `/fees.all`. Underpaying or Overpaying of fee in a transaction will result in a returned error.
 - Integrator can create a transaction with a valid fee amount via `/transaction.create` API endpoint by specifying fee tokens. Alternatively, a client can build the transaction with valid fee from scratch via a call to fees.all prior to transaction build process.
 - Currently, the fees are statically set per each environment. This is expected to change once a more dynamic fee model has been applied, however, consuming fee API is expected to stay the same from integration’s point of view.
-- Refer to our guide to transaction fee for more example: https://docs.omg.network/fees
+- Refer to our guide to transaction fee for more example: https://docs.omg.network/network/fees
 
 ### Watcher vs. WatcherInfo
 Two flavors of the watcher are now available: Watcher and WatcherInfo.

--- a/docs/network/in-flight-exits.md
+++ b/docs/network/in-flight-exits.md
@@ -102,13 +102,6 @@ async function startInflightExit() {
     });
   }
 
-  // fetch ETH fee amount from the Watcher
-  const allFees = await childChain.getFees();
-  const feesForTransactions = allFees["1"];
-  const { amount: feeAmount } = feesForTransactions.find(
-    (i) => i.currency === OmgUtil.transaction.ETH_CURRENCY
-  );
-
   // construct a transaction body
   const transactionBody = await childChain.createTransaction({
     owner: "0x8CB0DE6206f459812525F2BA043b14155C2230C0",

--- a/docs/network/transfers.md
+++ b/docs/network/transfers.md
@@ -135,23 +135,16 @@ Transactions are signed using the [EIP-712](https://github.com/ethereum/EIPs/blo
 }
 ```
 
-Note, the child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network. To get more details on how the fees are defined, please refer to [Fees](/network/fees).
+The child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network, the fee amount is automatically calculated by the child chain. To get more details on how the fees are defined, please refer to [Fees](/network/fees). Note, testnet and mainnet might support different currencies for fees.
 
 #### 3.1 Method A
 
-The most "granular" implementation of transfer includes fetching fees, creating, typing, signing and submitting the transaction. Such an approach will have the following structure of the code:
+The most "granular" implementation of transfer includes creating, typing, signing and submitting the transaction. Such an approach will have the following structure of the code:
 
 > This method demonstrates a transfer made in ETH. If you want to make an ERC20 transfer, change the `currency` value to a corresponding smart contract address. 
 
 ```js
 async function transfer() {
-  // fetch ETH fee amount from the Watcher
-  const allFees = await childChain.getFees();
-  const feesForTransactions = allFees["1"];
-  const { amount: feeAmount } = feesForTransactions.find(
-    (i) => i.currency === OmgUtil.transaction.ETH_CURRENCY
-  );
-
   // construct a transaction body
   const transactionBody = await childChain.createTransaction({
     owner: "0x8CB0DE6206f459812525F2BA043b14155C2230C0",
@@ -163,8 +156,7 @@ async function transfer() {
       },
     ],
     fee: {
-      currency: OmgUtil.transaction.ETH_CURRENCY,
-      amount: feeAmount,
+      currency: OmgUtil.transaction.ETH_CURRENCY
     },
     metadata: "data",
   });

--- a/docs/network/transfers.md
+++ b/docs/network/transfers.md
@@ -135,7 +135,7 @@ Transactions are signed using the [EIP-712](https://github.com/ethereum/EIPs/blo
 }
 ```
 
-Note, the child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network. To get more details on how the fees are defined, please refer to [Fees](https://docs.omg.network/fees).
+Note, the child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network. To get more details on how the fees are defined, please refer to [Fees](/network/fees).
 
 #### 3.1 Method A
 

--- a/website/versioned_docs/version-V1/migration-0.3-0.4.md
+++ b/website/versioned_docs/version-V1/migration-0.3-0.4.md
@@ -14,7 +14,7 @@ original_id: migration-0.3-0.4
 - The fee amount must be correct as specified in `/fees.all`. Underpaying or Overpaying of fee in a transaction will result in a returned error.
 - Integrator can create a transaction with a valid fee amount via `/transaction.create` API endpoint by specifying fee tokens. Alternatively, a client can build the transaction with valid fee from scratch via a call to fees.all prior to transaction build process.
 - Currently, the fees are statically set per each environment. This is expected to change once a more dynamic fee model has been applied, however, consuming fee API is expected to stay the same from integration’s point of view.
-- Refer to our guide to transaction fee for more example: https://docs.omg.network/fees
+- Refer to our guide to transaction fee for more example: https://docs.omg.network/network/fees
 
 ### Watcher vs. WatcherInfo
 Two flavors of the watcher are now available: Watcher and WatcherInfo.

--- a/website/versioned_docs/version-V1/network/in-flight-exits.md
+++ b/website/versioned_docs/version-V1/network/in-flight-exits.md
@@ -103,13 +103,6 @@ async function startInflightExit() {
     });
   }
 
-  // fetch ETH fee amount from the Watcher
-  const allFees = await childChain.getFees();
-  const feesForTransactions = allFees["1"];
-  const { amount: feeAmount } = feesForTransactions.find(
-    (i) => i.currency === OmgUtil.transaction.ETH_CURRENCY
-  );
-
   // construct a transaction body
   const transactionBody = await childChain.createTransaction({
     owner: "0x8CB0DE6206f459812525F2BA043b14155C2230C0",

--- a/website/versioned_docs/version-V1/network/transfers.md
+++ b/website/versioned_docs/version-V1/network/transfers.md
@@ -136,23 +136,16 @@ Transactions are signed using the [EIP-712](https://github.com/ethereum/EIPs/blo
 }
 ```
 
-Note, the child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network. To get more details on how the fees are defined, please refer to [Fees](/network/fees).
+The child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network, the fee amount is automatically calculated by the child chain. To get more details on how the fees are defined, please refer to [Fees](/network/fees). Note, testnet and mainnet might support different currencies for fees.
 
 #### 3.1 Method A
 
-The most "granular" implementation of transfer includes fetching fees, creating, typing, signing and submitting the transaction. Such an approach will have the following structure of the code:
+The most "granular" implementation of transfer includes creating, typing, signing and submitting the transaction. Such an approach will have the following structure of the code:
 
 > This method demonstrates a transfer made in ETH. If you want to make an ERC20 transfer, change the `currency` value to a corresponding smart contract address. 
 
 ```js
 async function transfer() {
-  // fetch ETH fee amount from the Watcher
-  const allFees = await childChain.getFees();
-  const feesForTransactions = allFees["1"];
-  const { amount: feeAmount } = feesForTransactions.find(
-    (i) => i.currency === OmgUtil.transaction.ETH_CURRENCY
-  );
-
   // construct a transaction body
   const transactionBody = await childChain.createTransaction({
     owner: "0x8CB0DE6206f459812525F2BA043b14155C2230C0",
@@ -164,8 +157,7 @@ async function transfer() {
       },
     ],
     fee: {
-      currency: OmgUtil.transaction.ETH_CURRENCY,
-      amount: feeAmount,
+      currency: OmgUtil.transaction.ETH_CURRENCY
     },
     metadata: "data",
   });

--- a/website/versioned_docs/version-V1/network/transfers.md
+++ b/website/versioned_docs/version-V1/network/transfers.md
@@ -136,7 +136,7 @@ Transactions are signed using the [EIP-712](https://github.com/ethereum/EIPs/blo
 }
 ```
 
-Note, the child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network. To get more details on how the fees are defined, please refer to [Fees](https://docs.omg.network/fees).
+Note, the child chain server collects fees for sending a transaction. The fee can be paid in a variety of supported tokens by the network. To get more details on how the fees are defined, please refer to [Fees](/network/fees).
 
 #### 3.1 Method A
 


### PR DESCRIPTION
## Overview

Changes in fees documentation.

## Changes

- Changed references to fees in transfers and migration guides.
- Removed fee collection from the `transfers` and `in-flught-exits` code samples.
- Removed `feeAmount` from the `fee` object in code samples.