### PR TITLE
Demo project changes

### DIFF
--- a/docs/network/balances.md
+++ b/docs/network/balances.md
@@ -172,24 +172,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Retrieve Balances`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/01-balances) on the left side, observe the logs on the right.
+5. Select [`Retrieve Balances`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/01-balances) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/balances.md
+++ b/docs/network/balances.md
@@ -175,7 +175,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/network/deposits.md
+++ b/docs/network/deposits.md
@@ -177,7 +177,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/network/deposits.md
+++ b/docs/network/deposits.md
@@ -174,24 +174,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Make an ETH Deposit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/02-deposit-eth) or [`Make an ERC20 Deposit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/02-deposit-erc20) on the left side, observe the logs on the right.
+5. Select [`Make an ETH Deposit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/02-deposit-eth) or [`Make an ERC20 Deposit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/02-deposit-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/in-flight-exits.md
+++ b/docs/network/in-flight-exits.md
@@ -250,7 +250,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/network/in-flight-exits.md
+++ b/docs/network/in-flight-exits.md
@@ -247,24 +247,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Start an In-flight ETH Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-inflight-eth) on the left side, observe the logs on the right.
+5. Select [`Start an In-flight ETH Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-inflight-eth) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/process-exits.md
+++ b/docs/network/process-exits.md
@@ -125,7 +125,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/network/process-exits.md
+++ b/docs/network/process-exits.md
@@ -122,24 +122,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Process an ETH Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-process-eth) or [`Process an ERC20 Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
+5. Select [`Process an ETH Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-process-eth) or [`Process an ERC20 Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/standard-exits.md
+++ b/docs/network/standard-exits.md
@@ -191,7 +191,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/network/standard-exits.md
+++ b/docs/network/standard-exits.md
@@ -188,24 +188,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Start a Standard ETH Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-standard-eth) or [`Start a Standard ERC20 Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
+5. Select [`Start a Standard ETH Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-standard-eth) or [`Start a Standard ERC20 Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/start.md
+++ b/docs/network/start.md
@@ -8,7 +8,7 @@ This section aims to give a deeper technical explanation and code implementation
 
 ## Code Samples
 
-The majority of tutorials have sufficient code as a part of a larger [OMG Samples](https://github.com/omgnetwork/omg-samples) project. This project contains code samples in multiple programming languages. You may find a full implementation of a chosen tutorial for your preferred language in the respective folder (e.g. `omg-js` for Javascript).
+The majority of tutorials have sufficient code as a part of a larger [OMG Samples](https://github.com/omgnetwork/omg-js-samples) project. This project contains code samples in multiple programming languages. You may find a full implementation of a chosen tutorial for your preferred language in the respective folder (e.g. `omg-js` for Javascript).
  
 > Currently, all code samples are implemented in Javascript as a part of [omg-js](https://github.com/omgnetwork/omg-js) library.
 

--- a/docs/network/transfers.md
+++ b/docs/network/transfers.md
@@ -259,7 +259,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/network/transfers.md
+++ b/docs/network/transfers.md
@@ -256,24 +256,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Make an ETH Transaction`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/03-transaction-eth) or [`Make an ERC20 Transaction`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/03-transaction-erc20) on the left side, observe the logs on the right.
+5. Select [`Make an ETH Transaction`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/03-transaction-eth) or [`Make an ERC20 Transaction`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/03-transaction-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/utxos.md
+++ b/docs/network/utxos.md
@@ -227,24 +227,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 6. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-7. Select [`Show UTXOs`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/04-utxo-show), [`Merge UTXOs`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/04-utxo-merge) or [`Split UTXOs`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/04-utxo-split) on the left side, observe the logs on the right.
+7. Select [`Show UTXOs`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/04-utxo-show), [`Merge UTXOs`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/04-utxo-merge) or [`Split UTXOs`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/04-utxo-split) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/docs/network/utxos.md
+++ b/docs/network/utxos.md
@@ -230,7 +230,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/docs/watcher/run-watcher-locally.md
+++ b/docs/watcher/run-watcher-locally.md
@@ -286,5 +286,5 @@ watcher_info_1   | 2020-05-30 06:13:36.445 [info] module=Phoenix.Endpoint.Cowboy
 ### 6. Test Your Watcher
 
 The last step is to test that your Watcher is working properly. There are two ways to do that:
-1. Use `http://localhost:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-samples). 
+1. Use `http://localhost:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-js-samples). 
 2. Make a transaction or other operation using [Watcher Info API](https://docs.omg.network/elixir-omg/docs-ui/?url=master%2Foperator_api_specs.yaml&urls.primaryName=master%2Finfo_api_specs).

--- a/docs/watcher/run-watcher-vps.md
+++ b/docs/watcher/run-watcher-vps.md
@@ -355,7 +355,7 @@ watcher_info_1   | 2020-05-30 06:13:36.445 [info] module=Phoenix.Endpoint.Cowboy
 ### 9. Test Your Watcher
 
 There are two ways to test that your Watcher is working properly:
-1. Use `http://$REMOTE_SERVER:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-samples). 
+1. Use `http://$REMOTE_SERVER:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-js-samples). 
 2. Make a transaction or another operation using [Watcher Info API](https://docs.omg.network/elixir-omg/docs-ui/?url=master%2Foperator_api_specs.yaml&urls.primaryName=master%2Finfo_api_specs).
 
 > - `$REMOTE_SERVER` - an IP address of your remote server.

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -25,8 +25,8 @@ class Footer extends React.Component {
           url: "https://github.com/omgnetwork/web-wallet",
         },
         {
-          content: "OMG Samples",
-          url: "https://github.com/omgnetwork/omg-samples",
+          content: "omg-js samples",
+          url: "https://github.com/omgnetwork/omg-js-samples",
         },
       ],
       api: [
@@ -54,7 +54,7 @@ class Footer extends React.Component {
         },
         {
           content: "Tutorials",
-          url: "/network/tutorials",
+          url: "/network/start",
         },
         {
           content: "Plasma Contracts",
@@ -125,7 +125,7 @@ class Footer extends React.Component {
     const FooterItem = (props) => {
       return (
         <span className="footer-item">
-          <a target="_blank" href={props.href}>
+          <a href={props.href}>
             {props.content}
           </a>
         </span>
@@ -134,7 +134,7 @@ class Footer extends React.Component {
 
     const FooterItemSocial = (props) => {
       return (
-        <a target="_blank" href={props.href}>
+        <a href={props.href}>
           <img src={props.src} alt={props.alt} className="footer-social" />
         </a>
       );

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -124,9 +124,9 @@ class Index extends React.Component {
           imageLink: `${baseUrl}img/icons/dev02.svg`,
         },
         {
-          title: "OMG Samples",
-          content: "Browse and run locally various code samples.",
-          url: "https://github.com/omgnetwork/omg-samples",
+          title: "omg-js samples",
+          content: "Browse and run locally omg-js code samples.",
+          url: "https://github.com/omgnetwork/omg-js-samples",
           imageLink: `${baseUrl}img/icons/collecting.svg`,
         },
       ],
@@ -175,7 +175,7 @@ class Index extends React.Component {
     const ImagedCard = (props) => {
       return (
         <div className="col-12 col-md-4 mb-3">
-          <a href={props.url} target="_blank">
+          <a href={props.url}>
             <div className="row box">
               <div className="col-3 d-none d-lg-block align-self-center">
                 <img
@@ -197,7 +197,7 @@ class Index extends React.Component {
     const CalloutCard = (props) => {
       return (
         <div className="col-12 col-md-4 mb-3">
-          <a href={props.url} target="_blank">
+          <a href={props.url}>
             <div className="row box callout callout-primary">
               <div className="col-12 pb-2">
                 <h3>{props.title}</h3>

--- a/website/versioned_docs/version-V1/network/balances.md
+++ b/website/versioned_docs/version-V1/network/balances.md
@@ -173,24 +173,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Retrieve Balances`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/01-balances) on the left side, observe the logs on the right.
+5. Select [`Retrieve Balances`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/01-balances) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/network/balances.md
+++ b/website/versioned_docs/version-V1/network/balances.md
@@ -176,7 +176,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/deposits.md
+++ b/website/versioned_docs/version-V1/network/deposits.md
@@ -178,7 +178,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/deposits.md
+++ b/website/versioned_docs/version-V1/network/deposits.md
@@ -175,24 +175,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Make an ETH Deposit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/02-deposit-eth) or [`Make an ERC20 Deposit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/02-deposit-erc20) on the left side, observe the logs on the right.
+5. Select [`Make an ETH Deposit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/02-deposit-eth) or [`Make an ERC20 Deposit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/02-deposit-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/network/in-flight-exits.md
+++ b/website/versioned_docs/version-V1/network/in-flight-exits.md
@@ -251,7 +251,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/in-flight-exits.md
+++ b/website/versioned_docs/version-V1/network/in-flight-exits.md
@@ -248,24 +248,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Start an In-flight ETH Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-inflight-eth) on the left side, observe the logs on the right.
+5. Select [`Start an In-flight ETH Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-inflight-eth) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/network/process-exits.md
+++ b/website/versioned_docs/version-V1/network/process-exits.md
@@ -126,7 +126,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/process-exits.md
+++ b/website/versioned_docs/version-V1/network/process-exits.md
@@ -123,24 +123,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Process an ETH Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-process-eth) or [`Process an ERC20 Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
+5. Select [`Process an ETH Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-process-eth) or [`Process an ERC20 Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/network/standard-exits.md
+++ b/website/versioned_docs/version-V1/network/standard-exits.md
@@ -189,24 +189,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Start a Standard ETH Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-standard-eth) or [`Start a Standard ERC20 Exit`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
+5. Select [`Start a Standard ETH Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-standard-eth) or [`Start a Standard ERC20 Exit`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/05-exit-standard-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/network/standard-exits.md
+++ b/website/versioned_docs/version-V1/network/standard-exits.md
@@ -192,7 +192,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/start.md
+++ b/website/versioned_docs/version-V1/network/start.md
@@ -9,7 +9,7 @@ This section aims to give a deeper technical explanation and code implementation
 
 ## Code Samples
 
-The majority of tutorials have sufficient code as a part of a larger [OMG Samples](https://github.com/omgnetwork/omg-samples) project. This project contains code samples in multiple programming languages. You may find a full implementation of a chosen tutorial for your preferred language in the respective folder (e.g. `omg-js` for Javascript).
+The majority of tutorials have sufficient code as a part of a larger [OMG Samples](https://github.com/omgnetwork/omg-js-samples) project. This project contains code samples in multiple programming languages. You may find a full implementation of a chosen tutorial for your preferred language in the respective folder (e.g. `omg-js` for Javascript).
  
 > Currently, all code samples are implemented in Javascript as a part of [omg-js](https://github.com/omgnetwork/omg-js) library.
 

--- a/website/versioned_docs/version-V1/network/transfers.md
+++ b/website/versioned_docs/version-V1/network/transfers.md
@@ -257,24 +257,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 4. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-5. Select [`Make an ETH Transaction`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/03-transaction-eth) or [`Make an ERC20 Transaction`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/03-transaction-erc20) on the left side, observe the logs on the right.
+5. Select [`Make an ETH Transaction`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/03-transaction-eth) or [`Make an ERC20 Transaction`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/03-transaction-erc20) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/network/transfers.md
+++ b/website/versioned_docs/version-V1/network/transfers.md
@@ -260,7 +260,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/utxos.md
+++ b/website/versioned_docs/version-V1/network/utxos.md
@@ -231,7 +231,7 @@ For running a full `omg-js` code sample for the tutorial, please use the followi
 1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-js-samples
+git clone https://github.com/omgnetwork/omg-js-samples.git
 ```
 
 2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).

--- a/website/versioned_docs/version-V1/network/utxos.md
+++ b/website/versioned_docs/version-V1/network/utxos.md
@@ -228,24 +228,23 @@ This section provides a demo project that contains a detailed implementation of 
 
 For running a full `omg-js` code sample for the tutorial, please use the following steps:
 
-1. Clone [OMG Samples](https://github.com/omgnetwork/omg-samples) repository:
+1. Clone [omg-js-samples](https://github.com/omgnetwork/omg-js-samples) repository:
 
 ```
-git clone https://github.com/omgnetwork/omg-samples.git
+git clone https://github.com/omgnetwork/omg-js-samples
 ```
 
-2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-samples/tree/master/omg-js#setup).
+2. Create `.env` file and provide the [required configuration values](https://github.com/omgnetwork/omg-js-samples/tree/master/omg-js#setup).
 
 3. Run these commands:
 
 ```
-cd omg-js
 npm install
 npm run start
 ```
 
 6. Open your browser at [http://localhost:3000](http://localhost:3000). 
 
-7. Select [`Show UTXOs`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/04-utxo-show), [`Merge UTXOs`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/04-utxo-merge) or [`Split UTXOs`](https://github.com/omgnetwork/omg-samples/tree/master/omg-js/app/04-utxo-split) on the left side, observe the logs on the right.
+7. Select [`Show UTXOs`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/04-utxo-show), [`Merge UTXOs`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/04-utxo-merge) or [`Split UTXOs`](https://github.com/omgnetwork/omg-js-samples/tree/master/app/04-utxo-split) on the left side, observe the logs on the right.
 
-> Code samples for all tutorials use the same repository — `omg-samples`, thus you have to set up the project and install dependencies only one time.
+> Code samples for all tutorials use the same repository — `omg-js-samples`, thus you have to set up the project and install dependencies only one time.

--- a/website/versioned_docs/version-V1/watcher/run-watcher-locally.md
+++ b/website/versioned_docs/version-V1/watcher/run-watcher-locally.md
@@ -287,5 +287,5 @@ watcher_info_1   | 2020-05-30 06:13:36.445 [info] module=Phoenix.Endpoint.Cowboy
 ### 6. Test Your Watcher
 
 The last step is to test that your Watcher is working properly. There are two ways to do that:
-1. Use `http://localhost:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-samples). 
+1. Use `http://localhost:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-js-samples). 
 2. Make a transaction or other operation using [Watcher Info API](https://docs.omg.network/elixir-omg/docs-ui/?url=master%2Foperator_api_specs.yaml&urls.primaryName=master%2Finfo_api_specs).

--- a/website/versioned_docs/version-V1/watcher/run-watcher-vps.md
+++ b/website/versioned_docs/version-V1/watcher/run-watcher-vps.md
@@ -356,7 +356,7 @@ watcher_info_1   | 2020-05-30 06:13:36.445 [info] module=Phoenix.Endpoint.Cowboy
 ### 9. Test Your Watcher
 
 There are two ways to test that your Watcher is working properly:
-1. Use `http://$REMOTE_SERVER:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-samples). 
+1. Use `http://$REMOTE_SERVER:7534` as a `WATCHER_URL` value in your configs to make a transfer in your own or one of the OMG Network projects, such as [OMG Samples](https://github.com/omgnetwork/omg-js-samples). 
 2. Make a transaction or another operation using [Watcher Info API](https://docs.omg.network/elixir-omg/docs-ui/?url=master%2Foperator_api_specs.yaml&urls.primaryName=master%2Finfo_api_specs).
 
 > - `$REMOTE_SERVER` - an IP address of your remote server.


### PR DESCRIPTION
## Overview

omg-js code samples are moving into a separate repository. This requires the change of all of the references to the demo project.

## Changes

- Changed the references from [OMG Samples](https://github.com/omgnetwork/omg-samples) to [omg-js-samples](https://github.com/omgnetwork/omg-js-samples).